### PR TITLE
add flow control and TV id as user params

### DIFF
--- a/custom_components/lg_tv_serial/__init__.py
+++ b/custom_components/lg_tv_serial/__init__.py
@@ -130,7 +130,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
 
-    api = LgTv(entry.data["serial_url"])
+    api = LgTv(entry.data["serial_url"], entry.data["set_id"], entry.data["rtscts"], entry.data["dsrdtr"], entry.data["xonxoff"])
 
     @callback
     async def on_disconnect():

--- a/custom_components/lg_tv_serial/__init__.py
+++ b/custom_components/lg_tv_serial/__init__.py
@@ -130,7 +130,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
 
-    api = LgTv(entry.data["serial_url"], entry.data["set_id"], entry.data["rtscts"], entry.data["dsrdtr"], entry.data["xonxoff"])
+    api = LgTv(
+        entry.data["serial_url"],
+        entry.data.get("set_id", 0),
+        entry.data.get("rtscts", False),
+        entry.data.get("dsrdtr", False),
+        entry.data.get("xonxoff", False)
+    )
 
     @callback
     async def on_disconnect():

--- a/custom_components/lg_tv_serial/config_flow.py
+++ b/custom_components/lg_tv_serial/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 
-from .const import DOMAIN, SERIAL_URL
+from .const import DOMAIN, SERIAL_URL, SET_ID, RTSCTS, DSRDTR, XONXOFF
 from .lgtv_api import LgTv
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,6 +19,10 @@ _LOGGER = logging.getLogger(__name__)
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(SERIAL_URL): str,
+        vol.Optional(SET_ID, default=0): vol.All(int, vol.Range(min=0, max=99)),
+        vol.Optional(RTSCTS, default=False): bool,
+        vol.Optional(DSRDTR, default=False): bool,
+        vol.Optional(XONXOFF, default=False): bool,
     }
 )
 
@@ -29,7 +33,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
     try:
-        async with LgTv(data[SERIAL_URL]) as api:
+        async with LgTv(data[SERIAL_URL], data[SET_ID], data[RTSCTS], data[DSRDTR], data[XONXOFF]) as api:
             await api.connect()
             if await api.get_power_on() is None:
                 raise CannotConnect("No response from LG TV")

--- a/custom_components/lg_tv_serial/const.py
+++ b/custom_components/lg_tv_serial/const.py
@@ -8,6 +8,14 @@ DOMAIN = "lg_tv_serial"
 
 SERIAL_URL = "serial_url"
 
+SET_ID = "set_id"
+
+RTSCTS = "rtscts"
+
+DSRDTR = "dsrdtr"
+
+XONXOFF = "xonxoff"
+
 ATTR_COMMANDS = "commands"
 
 SERVICE_SEND_RAW = "send_raw"

--- a/custom_components/lg_tv_serial/lgtv_api.py
+++ b/custom_components/lg_tv_serial/lgtv_api.py
@@ -231,9 +231,12 @@ def parse_response(reponse: bytearray) -> Response | None:
 class LgTv:
     """Control an LG TV with serial port."""
 
-    def __init__(self, serial_url, set_id=0) -> None:
+    def __init__(self, serial_url, set_id=0, rtscts=False, dsrdtr=False, xonxoff=False) -> None:
         self._serial_url = serial_url
         self._set_id = set_id
+        self._rtscts = rtscts
+        self._dsrdtr = dsrdtr
+        self._xonxoff = xonxoff
         self._lock = asyncio.Lock()
         self._on_disconnect = None
         self._writer: asyncio.StreamWriter | None = None
@@ -253,7 +256,8 @@ class LgTv:
         try:
             (self._reader, self._writer) = (
                 await serial_asyncio_fast.open_serial_connection(
-                    url=self._serial_url, baudrate=9600
+                    url=self._serial_url, baudrate=9600,
+                    rtscts=self._rtscts, dsrdtr=self._dsrdtr, xonxoff=self._xonxoff
                 )
             )
 
@@ -549,8 +553,8 @@ class LgTv:
         )
 
 
-async def main(serial_url: str):
-    async with LgTv(serial_url) as tv:
+async def main(serial_url: str, set_id: int = 0, rtscts: bool = False, dsrdtr: bool = False, xonxoff: bool = False):
+    async with LgTv(serial_url, set_id, rtscts, dsrdtr, xonxoff) as tv:
         await tv.connect()
 
         print("--- Current power state")

--- a/custom_components/lg_tv_serial/translations/en.json
+++ b/custom_components/lg_tv_serial/translations/en.json
@@ -13,7 +13,7 @@
                 "description": "The serial port can be a normal serial port like '/dev/ttyUSB0', but can also be any [URL handler as supported by PySerial](https://pyserial.readthedocs.io/en/latest/url_handlers.html).\n\nThis can come in handy when addressing USB adapters by serial with `hwgrep://` or use `rfc2217://hostname_or_ip` to connect through an rfc2217 compatible server for more advanced usecases.",
                 "data": {
                     "serial_url": "Serial port e.g. /dev/ttyUSB0",
-                    "set_id": "TV id number (optional)",
+                    "set_id": "TV ID number (optional)",
                     "rtscts": "Enable RTS/CTS hardware flow control (optional)",
                     "dsrdtr": "Enable DSR/DTR hardware flow control (optional)",
                     "xonxoff": "Enable XON/XOFF software flow control (optional)"

--- a/custom_components/lg_tv_serial/translations/en.json
+++ b/custom_components/lg_tv_serial/translations/en.json
@@ -12,7 +12,11 @@
             "user": {
                 "description": "The serial port can be a normal serial port like '/dev/ttyUSB0', but can also be any [URL handler as supported by PySerial](https://pyserial.readthedocs.io/en/latest/url_handlers.html).\n\nThis can come in handy when addressing USB adapters by serial with `hwgrep://` or use `rfc2217://hostname_or_ip` to connect through an rfc2217 compatible server for more advanced usecases.",
                 "data": {
-                    "serial_url": "Serial port e.g. /dev/ttyUSB0"
+                    "serial_url": "Serial port e.g. /dev/ttyUSB0",
+                    "set_id": "TV id number (optional)",
+                    "rtscts": "Enable RTS/CTS hardware flow control (optional)",
+                    "dsrdtr": "Enable DSR/DTR hardware flow control (optional)",
+                    "xonxoff": "Enable XON/XOFF software flow control (optional)"
                 }
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional serial port configuration when setting up the LG TV integration: TV ID plus three flow-control options (RTS/CTS, DSR/DTR, XON/XOFF) so users can customize serial communication.
* **Documentation**
  * Added user-facing labels and optional descriptions for the new settings in the integration translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->