### PR TITLE
Remove device filter from services yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,8 @@ See example below, check out the developer tools in Home Assistant for more deta
 
 ```yaml
 action: lg_tv_serial.send_raw
-target:
-  entity_id:
-    - media_player.lg_tv
 data:
+  config_entry: 84bcdb836062423ee2c8abd7a9ed444e
   command1: k
   command2: e
   data0: "1"
@@ -62,7 +60,7 @@ data:
 
 ### Home Assistant Community Store (HACS)
 
-*Recommended as you get notifications of updates*
+*Recommended because you get notifications of updates*
 
 HACS is a 3rd party downloader for Home Assistant to easily install and update custom integrations made by the community. More information and installation instructions can be found on their site https://hacs.xyz/
 

--- a/custom_components/lg_tv_serial/__init__.py
+++ b/custom_components/lg_tv_serial/__init__.py
@@ -90,12 +90,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                         data.append(parsed_value)
                     else:
                         raise ValueError
-                except (TypeError, ValueError):
+                except (TypeError, ValueError) as e:
                     raise ServiceValidationError(
                         translation_domain=DOMAIN,
                         translation_key="invalid_data_value",
                         translation_placeholders={"data_byte": attr, "wrong_value": value},
-                    )
+                    ) from e
 
         coordinator: LgTvCoordinator = hass.data[DOMAIN][
             config_entry.entry_id
@@ -156,7 +156,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         return True
     except ConnectionError as e:
-        raise ConfigEntryNotReady(f"Could not connect to LG TV: {entry.title}")
+        raise ConfigEntryNotReady(f"Could not connect to LG TV: {entry.title}") from e
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/lg_tv_serial/__init__.py
+++ b/custom_components/lg_tv_serial/__init__.py
@@ -6,9 +6,7 @@ from homeassistant.config_entries import ConfigEntry, OperationNotAllowed
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
-from homeassistant.helpers.service import async_extract_config_entry_ids
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.config_validation import make_entity_service_schema
 
 
 from .const import (

--- a/custom_components/lg_tv_serial/__init__.py
+++ b/custom_components/lg_tv_serial/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.config_validation import make_entity_service_schema
 from .const import (
     ATTR_COMMAND_1,
     ATTR_COMMAND_2,
+    ATTR_CONFIG_ENTRY,
     ATTR_DATA_0,
     ATTR_DATA_1,
     ATTR_DATA_2,
@@ -45,70 +46,62 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         Send raw command to the TV
         """
 
-        config_entry_ids = await async_extract_config_entry_ids(hass, call)
-        for config_entry_id in config_entry_ids:
-            # Need to check if it is our config entry since async_extract_config_entry_ids
-            # can return config entries from other integrations also
-            # (e.g. area id or devices with entities from multiple integrations)
-            if config_entry := hass.config_entries.async_get_entry(config_entry_id):
-                if (
-                    config_entry.domain == DOMAIN
-                    and config_entry.entry_id in hass.data[DOMAIN]
-                ):
+        if config_entry := hass.config_entries.async_get_entry(call.data.get(ATTR_CONFIG_ENTRY)):
 
-                    command1 = call.data.get(ATTR_COMMAND_1)
-                    if len(command1) != 1:
-                        raise ServiceValidationError(
-                            translation_domain=DOMAIN,
-                            translation_key="invalid_command_value",
-                            translation_placeholders={"command": ATTR_COMMAND_1, "wrong_value": command1},
-                        )
+            command1 = call.data.get(ATTR_COMMAND_1)
+            if len(command1) != 1:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_command_value",
+                    translation_placeholders={"command": ATTR_COMMAND_1, "wrong_value": command1},
+                )
 
-                    command2 = call.data.get(ATTR_COMMAND_2)
-                    if len(command2) != 1:
-                        raise ServiceValidationError(
-                            translation_domain=DOMAIN,
-                            translation_key="invalid_command_value",
-                            translation_placeholders={"command": ATTR_COMMAND_2, "wrong_value": command2},
-                        )
+            command2 = call.data.get(ATTR_COMMAND_2)
+            if len(command2) != 1:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_command_value",
+                    translation_placeholders={"command": ATTR_COMMAND_2, "wrong_value": command2},
+                )
 
-                    data: list[int | None] = []
-                    for attr in [
-                        ATTR_DATA_0,
-                        ATTR_DATA_1,
-                        ATTR_DATA_2,
-                        ATTR_DATA_3,
-                        ATTR_DATA_4,
-                        ATTR_DATA_5,
-                    ]:
-                        value = call.data.get(attr)
-                        if value is None:
-                            data.append(None)
+            data: list[int | None] = []
+            for attr in [
+                ATTR_DATA_0,
+                ATTR_DATA_1,
+                ATTR_DATA_2,
+                ATTR_DATA_3,
+                ATTR_DATA_4,
+                ATTR_DATA_5,
+            ]:
+                value = call.data.get(attr)
+                if value is None:
+                    data.append(None)
+                else:
+                    try:
+                        parsed_value = int(str(value).strip(), 0)  # 0 = auto base
+                        if 0 <= parsed_value <= 255:
+                            data.append(parsed_value)
                         else:
-                            try:
-                                parsed_value = int(str(value).strip(), 0)  # 0 = auto base
-                                if 0 <= parsed_value <= 255:
-                                    data.append(parsed_value)
-                                else:
-                                    raise ValueError
-                            except (TypeError, ValueError):
-                                raise ServiceValidationError(
-                                    translation_domain=DOMAIN,
-                                    translation_key="invalid_data_value",
-                                    translation_placeholders={"data_byte": attr, "wrong_value": value},
-                                )
+                            raise ValueError
+                    except (TypeError, ValueError):
+                        raise ServiceValidationError(
+                            translation_domain=DOMAIN,
+                            translation_key="invalid_data_value",
+                            translation_placeholders={"data_byte": attr, "wrong_value": value},
+                        )
 
-                    coordinator: LgTvCoordinator = hass.data[DOMAIN][
-                        config_entry.entry_id
-                    ]
-                    await coordinator.api.send_raw(command1, command2, data)
+            coordinator: LgTvCoordinator = hass.data[DOMAIN][
+                config_entry.entry_id
+            ]
+            await coordinator.api.send_raw(command1, command2, data)
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_SEND_RAW,
         async_send_raw,
-        schema=make_entity_service_schema(
+        schema=vol.Schema(
             {
+                vol.Required(ATTR_CONFIG_ENTRY): cv.string,
                 vol.Required(ATTR_COMMAND_1): cv.string,
                 vol.Required(ATTR_COMMAND_2): cv.string,
                 vol.Required(ATTR_DATA_0): cv.string,

--- a/custom_components/lg_tv_serial/config_flow.py
+++ b/custom_components/lg_tv_serial/config_flow.py
@@ -34,7 +34,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
             if await api.get_power_on() is None:
                 raise CannotConnect("No response from LG TV")
     except ConnectionError as e:
-        raise CannotConnect("Could not connect to LG TV, check port settings")
+        raise CannotConnect("Could not connect to LG TV, check port settings") from e
     
     return {"title": "LG TV"}
 

--- a/custom_components/lg_tv_serial/const.py
+++ b/custom_components/lg_tv_serial/const.py
@@ -12,6 +12,7 @@ ATTR_COMMANDS = "commands"
 
 SERVICE_SEND_RAW = "send_raw"
 
+ATTR_CONFIG_ENTRY = "config_entry"
 ATTR_COMMAND_1 = "command1"
 ATTR_COMMAND_2 = "command2"
 ATTR_DATA_0 = "data0"

--- a/custom_components/lg_tv_serial/services.yaml
+++ b/custom_components/lg_tv_serial/services.yaml
@@ -1,10 +1,10 @@
 send_raw:
-  target:
-    device:
-      integration: lg_tv_serial
-    entity:
-      integration: lg_tv_serial
   fields:
+    config_entry:
+      required: true
+      selector:
+        config_entry:
+          integration: lg_tv_serial
     command1:
       example: k
       required: true

--- a/custom_components/lg_tv_serial/translations/en.json
+++ b/custom_components/lg_tv_serial/translations/en.json
@@ -51,6 +51,9 @@
         },
         "connection_error": {
             "message": "An error occurred while communicating with the LG TV. Please check the connection."
+        },
+        "config_entry_not_found": {
+            "message": "Config entry not found {config_entry}."
         }
     },
     "services": {

--- a/custom_components/lg_tv_serial/translations/en.json
+++ b/custom_components/lg_tv_serial/translations/en.json
@@ -58,6 +58,10 @@
             "name": "Send raw LG TV serial command",
             "description": "Send raw commands to the TV. Intended for debugging. Check the command reference for more details.",
             "fields": {
+                "config_entry": {
+                    "name": "TV",
+                    "description": "TV configuration to send the command to."
+                },
                 "command1": {
                     "name": "Command 1",
                     "description": "First command letter."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * send_raw service now requires selecting a TV configuration via a config-entry selector.

* **Bug Fixes**
  * Stricter validation and clearer errors for raw data values and missing/invalid targets.
  * Improved error propagation for connection issues.

* **Documentation**
  * README example updated to use the new config-entry approach.
  * Community Store wording refined to clarify update notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->