### PR TITLE
Some cleanup after PR 9

### DIFF
--- a/custom_components/lg_tv_serial/__init__.py
+++ b/custom_components/lg_tv_serial/__init__.py
@@ -133,7 +133,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data.get("set_id", 0),
         entry.data.get("rtscts", False),
         entry.data.get("dsrdtr", False),
-        entry.data.get("xonxoff", False)
     )
 
     @callback

--- a/custom_components/lg_tv_serial/config_flow.py
+++ b/custom_components/lg_tv_serial/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for LG TV Serial integration."""
+
 from __future__ import annotations
 
 import logging
@@ -9,6 +10,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import selector
 
 
 from .const import DOMAIN, SERIAL_URL, SET_ID, RTSCTS, DSRDTR
@@ -19,9 +21,16 @@ _LOGGER = logging.getLogger(__name__)
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(SERIAL_URL): str,
-        vol.Optional(SET_ID, default=0): vol.All(int, vol.Range(min=0, max=99)),
-        vol.Optional(RTSCTS, default=False): bool,
-        vol.Optional(DSRDTR, default=False): bool,
+        vol.Required(SET_ID, default=0): vol.All(
+            selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0, max=99, mode=selector.NumberSelectorMode.BOX
+                ),
+            ),
+            vol.Coerce(int),
+        ),
+        vol.Required(RTSCTS, default=False): bool,
+        vol.Required(DSRDTR, default=False): bool,
     }
 )
 
@@ -32,13 +41,15 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
     try:
-        async with LgTv(data[SERIAL_URL], data[SET_ID], data[RTSCTS], data[DSRDTR]) as api:
+        async with LgTv(
+            data[SERIAL_URL], data[SET_ID], data[RTSCTS], data[DSRDTR]
+        ) as api:
             await api.connect()
             if await api.get_power_on() is None:
                 raise CannotConnect("No response from LG TV")
     except ConnectionError as e:
         raise CannotConnect("Could not connect to LG TV, check port settings") from e
-    
+
     return {"title": "LG TV"}
 
 

--- a/custom_components/lg_tv_serial/config_flow.py
+++ b/custom_components/lg_tv_serial/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 
-from .const import DOMAIN, SERIAL_URL, SET_ID, RTSCTS, DSRDTR, XONXOFF
+from .const import DOMAIN, SERIAL_URL, SET_ID, RTSCTS, DSRDTR
 from .lgtv_api import LgTv
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,6 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(SET_ID, default=0): vol.All(int, vol.Range(min=0, max=99)),
         vol.Optional(RTSCTS, default=False): bool,
         vol.Optional(DSRDTR, default=False): bool,
-        vol.Optional(XONXOFF, default=False): bool,
     }
 )
 
@@ -33,7 +32,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
     try:
-        async with LgTv(data[SERIAL_URL], data[SET_ID], data[RTSCTS], data[DSRDTR], data[XONXOFF]) as api:
+        async with LgTv(data[SERIAL_URL], data[SET_ID], data[RTSCTS], data[DSRDTR]) as api:
             await api.connect()
             if await api.get_power_on() is None:
                 raise CannotConnect("No response from LG TV")

--- a/custom_components/lg_tv_serial/const.py
+++ b/custom_components/lg_tv_serial/const.py
@@ -7,14 +7,9 @@ LOGGER = logging.getLogger(__package__)
 DOMAIN = "lg_tv_serial"
 
 SERIAL_URL = "serial_url"
-
 SET_ID = "set_id"
-
 RTSCTS = "rtscts"
-
 DSRDTR = "dsrdtr"
-
-XONXOFF = "xonxoff"
 
 ATTR_COMMANDS = "commands"
 

--- a/custom_components/lg_tv_serial/lgtv_api.py
+++ b/custom_components/lg_tv_serial/lgtv_api.py
@@ -231,12 +231,11 @@ def parse_response(reponse: bytearray) -> Response | None:
 class LgTv:
     """Control an LG TV with serial port."""
 
-    def __init__(self, serial_url, set_id=0, rtscts=False, dsrdtr=False, xonxoff=False) -> None:
+    def __init__(self, serial_url, set_id=0, rtscts=False, dsrdtr=False) -> None:
         self._serial_url = serial_url
         self._set_id = set_id
         self._rtscts = rtscts
         self._dsrdtr = dsrdtr
-        self._xonxoff = xonxoff
         self._lock = asyncio.Lock()
         self._on_disconnect = None
         self._writer: asyncio.StreamWriter | None = None
@@ -257,7 +256,7 @@ class LgTv:
             (self._reader, self._writer) = (
                 await serial_asyncio_fast.open_serial_connection(
                     url=self._serial_url, baudrate=9600,
-                    rtscts=self._rtscts, dsrdtr=self._dsrdtr, xonxoff=self._xonxoff
+                    rtscts=self._rtscts, dsrdtr=self._dsrdtr
                 )
             )
 
@@ -553,8 +552,8 @@ class LgTv:
         )
 
 
-async def main(serial_url: str, set_id: int = 0, rtscts: bool = False, dsrdtr: bool = False, xonxoff: bool = False):
-    async with LgTv(serial_url, set_id, rtscts, dsrdtr, xonxoff) as tv:
+async def main(serial_url: str, set_id: int = 0, rtscts: bool = False, dsrdtr: bool = False):
+    async with LgTv(serial_url, set_id, rtscts, dsrdtr) as tv:
         await tv.connect()
 
         print("--- Current power state")

--- a/custom_components/lg_tv_serial/lgtv_api.py
+++ b/custom_components/lg_tv_serial/lgtv_api.py
@@ -1,5 +1,6 @@
 """LG TV API, this should really be in its own package, but not now"""
 
+import argparse
 import asyncio
 from dataclasses import dataclass
 from enum import IntEnum, unique
@@ -552,7 +553,7 @@ class LgTv:
         )
 
 
-async def main(serial_url: str, set_id: int = 0, rtscts: bool = False, dsrdtr: bool = False):
+async def main(serial_url: str, set_id: int, rtscts: bool, dsrdtr: bool):
     async with LgTv(serial_url, set_id, rtscts, dsrdtr) as tv:
         await tv.connect()
 
@@ -586,14 +587,37 @@ async def main(serial_url: str, set_id: int = 0, rtscts: bool = False, dsrdtr: b
 
 
 if __name__ == "__main__":
-    if len(sys.argv) <= 1:
-        print("Must provide a serial_url parameter like:")
-        print("  COM3")
-        print("  /dev/ttyUSB0")
-        print("  socket://192.168.178.42:10003")
-        exit(1)
 
-    logging.basicConfig(level="INFO")
-    # logging.basicConfig(level="DEBUG")
+    parser = argparse.ArgumentParser(
+        description="Manual test for LGTV API"
+    )
+    parser.add_argument(
+        "serial_url",
+        help="Can be a devicename like COM3, /dev/ttyUSB0 or use socket://192.168.178.42:10003 for IP based connections.",
+    )
+    parser.add_argument(
+        "--set_id",
+        help="Set ID to use, default is 0 to address any TV (0-99)",
+        default=0,
+        type=int,
+    )
+    parser.add_argument(
+        "--rtscts",
+        action="store_true",
+        help="Enable RTS/CTS.",
+    )
+    parser.add_argument(
+        "--dsrdtr",
+        action="store_true",
+        help="Enable DSR/DTR.",
+    )
+    parser.add_argument(
+        "--loglevel",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
+        help="Define loglevel, default is INFO.",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=args.loglevel)
 
-    asyncio.run(main(sys.argv[1]))
+    asyncio.run(main(args.serial_url, set_id=args.set_id, rtscts=args.rtscts, dsrdtr=args.dsrdtr))

--- a/custom_components/lg_tv_serial/lgtv_api.py
+++ b/custom_components/lg_tv_serial/lgtv_api.py
@@ -600,6 +600,8 @@ if __name__ == "__main__":
         help="Set ID to use, default is 0 to address any TV (0-99)",
         default=0,
         type=int,
+        choices=range(0, 100),
+        metavar="SET_ID",
     )
     parser.add_argument(
         "--rtscts",

--- a/custom_components/lg_tv_serial/translations/en.json
+++ b/custom_components/lg_tv_serial/translations/en.json
@@ -13,9 +13,14 @@
                 "description": "The serial port can be a normal serial port like '/dev/ttyUSB0', but can also be any [URL handler as supported by PySerial](https://pyserial.readthedocs.io/en/latest/url_handlers.html).\n\nThis can come in handy when addressing USB adapters by serial with `hwgrep://` or use `rfc2217://hostname_or_ip` to connect through an rfc2217 compatible server for more advanced usecases.",
                 "data": {
                     "serial_url": "Serial port e.g. /dev/ttyUSB0",
-                    "set_id": "TV ID number (optional)",
-                    "rtscts": "Enable RTS/CTS hardware flow control (optional)",
-                    "dsrdtr": "Enable DSR/DTR hardware flow control (optional)"
+                    "set_id": "Set ID",
+                    "rtscts": "Enable RTS/CTS hardware flow control",
+                    "dsrdtr": "Enable DSR/DTR hardware flow control"
+                },
+                "data_description": {
+                    "set_id": "Use Set ID 0 to address any TV regardless of configured Set ID in the TV.",
+                    "rtscts": "Only enable if you have a fully wired serial cable.",
+                    "dsrdtr": "Only enable if you have a fully wired serial cable."
                 }
             }
         }

--- a/custom_components/lg_tv_serial/translations/en.json
+++ b/custom_components/lg_tv_serial/translations/en.json
@@ -15,8 +15,7 @@
                     "serial_url": "Serial port e.g. /dev/ttyUSB0",
                     "set_id": "TV ID number (optional)",
                     "rtscts": "Enable RTS/CTS hardware flow control (optional)",
-                    "dsrdtr": "Enable DSR/DTR hardware flow control (optional)",
-                    "xonxoff": "Enable XON/XOFF software flow control (optional)"
+                    "dsrdtr": "Enable DSR/DTR hardware flow control (optional)"
                 }
             }
         }


### PR DESCRIPTION
Add device dialog now looks like this:
<img width="602" height="627" alt="image" src="https://github.com/user-attachments/assets/48e04950-1f0d-415a-8fc5-bb8a2de8eb75" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Removed XONXOFF serial flow control option from the configuration UI.
  * Replaced SET_ID input with a numeric selector (0–99) for clearer selection.
  * Made RTSCTS and DSRDTR hardware flow control fields required (default false).

* **Documentation**
  * Updated configuration labels and added descriptive guidance for Set ID and hardware flow control, including cable requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->