### PR TITLE
Replace URLs with placeholders in translations

### DIFF
--- a/custom_components/lg_tv_serial/config_flow.py
+++ b/custom_components/lg_tv_serial/config_flow.py
@@ -17,6 +17,9 @@ from .const import DOMAIN, SERIAL_URL, SET_ID, RTSCTS, DSRDTR
 from .lgtv_api import LgTv
 
 _LOGGER = logging.getLogger(__name__)
+PYSERIAL_URL_HANDLERS_DOC = (
+    "https://pyserial.readthedocs.io/en/latest/url_handlers.html"
+)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -77,7 +80,10 @@ class LgTvConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={"pyserial_url": PYSERIAL_URL_HANDLERS_DOC},
         )
 
 

--- a/custom_components/lg_tv_serial/translations/en.json
+++ b/custom_components/lg_tv_serial/translations/en.json
@@ -10,7 +10,7 @@
         },
         "step": {
             "user": {
-                "description": "The serial port can be a normal serial port like '/dev/ttyUSB0', but can also be any [URL handler as supported by PySerial](https://pyserial.readthedocs.io/en/latest/url_handlers.html).\n\nThis can come in handy when addressing USB adapters by serial with `hwgrep://` or use `rfc2217://hostname_or_ip` to connect through an rfc2217 compatible server for more advanced usecases.",
+                "description": "The serial port can be a normal serial port like '/dev/ttyUSB0', but can also be any [URL handler as supported by PySerial]({pyserial_url}).\n\nThis can come in handy when addressing USB adapters by serial with `hwgrep://` or use `rfc2217://hostname_or_ip` to connect through an rfc2217 compatible server for more advanced usecases.",
                 "data": {
                     "serial_url": "Serial port e.g. /dev/ttyUSB0",
                     "set_id": "Set ID",


### PR DESCRIPTION
## Summary
replace hardcoded URL in translation description with a placeholder

Fixes failing hassfest checks in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved documentation link handling by introducing dynamic URL substitution, enabling better localization support and easier maintenance of external reference links in the configuration interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->