### PR TITLE
Migrate to serialx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Most entities can not be used when the TV is Off, so these entities become unava
 
 ## Features
 
-Connect through serial or any [URL handler supported by PySerial](https://pyserial.readthedocs.io/en/latest/url_handlers.html) this makes it possible to connect through networked tcp-2-serial solutions so your TV does not have to be connected directly to your Home Assistant machine.
+Connect through serial or any [URL handler supported by serialx](https://puddly.github.io/serialx/index.html) this makes it possible to connect through networked tcp-2-serial solutions so your TV does not have to be connected directly to your Home Assistant machine.
 
 ### Mediaplayer
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Most entities can not be used when the TV is Off, so these entities become unava
 
 ## Features
 
-Connect through serial or any [URL handler supported by serialx](https://puddly.github.io/serialx/index.html) this makes it possible to connect through networked tcp-2-serial solutions so your TV does not have to be connected directly to your Home Assistant machine.
+You can connect through local serial ports or [ESPHome serial proxies](https://esphome.io/components/serial_proxy/), both are automatically detected and listed during configuration.
+Or you can enter any [URL supported by serialx](https://puddly.github.io/serialx/index.html), so you can use eg. ser2net or generic serial-over-ethernet hardware.
+This way your TV does not have to be connected directly to your Home Assistant machine.
 
 ### Mediaplayer
 

--- a/custom_components/lg_tv_serial/config_flow.py
+++ b/custom_components/lg_tv_serial/config_flow.py
@@ -27,7 +27,7 @@ ESPHOME_SERIAL_PROXY_DOC = (
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(SERIAL_URL): str,
+        vol.Required(SERIAL_URL): selector.SerialPortSelector(),
         vol.Required(SET_ID, default=0): vol.All(
             selector.NumberSelector(
                 selector.NumberSelectorConfig(

--- a/custom_components/lg_tv_serial/config_flow.py
+++ b/custom_components/lg_tv_serial/config_flow.py
@@ -17,8 +17,12 @@ from .const import DOMAIN, SERIAL_URL, SET_ID, RTSCTS, DSRDTR
 from .lgtv_api import LgTv
 
 _LOGGER = logging.getLogger(__name__)
-PYSERIAL_URL_HANDLERS_DOC = (
-    "https://pyserial.readthedocs.io/en/latest/url_handlers.html"
+
+SERIALX_URL_HANDLERS_DOC = (
+    "https://puddly.github.io/serialx/index.html"
+)
+ESPHOME_SERIAL_PROXY_DOC = (
+    "https://esphome.io/components/serial_proxy/"
 )
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
@@ -83,7 +87,7 @@ class LgTvConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
-            description_placeholders={"pyserial_url": PYSERIAL_URL_HANDLERS_DOC},
+            description_placeholders={"serialx_url": SERIALX_URL_HANDLERS_DOC, "esphome_url": ESPHOME_SERIAL_PROXY_DOC},
         )
 
 

--- a/custom_components/lg_tv_serial/lgtv_api.py
+++ b/custom_components/lg_tv_serial/lgtv_api.py
@@ -265,8 +265,8 @@ class LgTv:
 
             # Only install on_disconnect after connection seems to work to avoid triggering it while not really connected
             self._on_disconnect = on_disconnect
-        except (OSError, IOError):
-            raise ConnectionError("Could not connect to LG TV, check the port settings")
+        except OSError as e:
+            raise ConnectionError("Could not connect to LG TV, check the port settings") from e
 
     async def close(self):
         await self._close(False)
@@ -281,7 +281,7 @@ class LgTv:
                 await self._writer.wait_closed()
             except ConnectionError:
                 logger.debug("Connection error while closing", exc_info=True)
-            except (OSError, IOError):
+            except OSError:
                 logger.debug("Serial exception error while closing", exc_info=True)
 
     async def _do_command(
@@ -349,19 +349,12 @@ class LgTv:
                 logger.warning("Connection error", exc_info=True)
                 await self._close(True)
                 raise e
-            except (OSError, IOError) as e:
+            except OSError as e:
                 logger.warning("Serial error", exc_info=True)
                 # Why try to close? Can result in more exceptions...
                 # Not sure what happens then
                 await self._close(True)
                 raise ConnectionError("Serial connection error") from e
-            except OSError as e:
-                # This can be thrown from asyncio, e.g. when Host is not reachable
-                # Not catching resulted in HA not giving up and huge logfile :/
-                logger.warning("OSError error", exc_info=True)
-                # Make it a connection error, since that is what the LG TV API
-                # is "documented" to throw on issues (and will result in reload in HA)
-                raise ConnectionError from e
 
             return None
 

--- a/custom_components/lg_tv_serial/lgtv_api.py
+++ b/custom_components/lg_tv_serial/lgtv_api.py
@@ -7,8 +7,9 @@ from enum import IntEnum, unique
 import logging
 import re
 import sys
+from serialx import SerialException
 
-import serialx  # type: ignore
+import serialx
 
 
 logger = logging.getLogger(__name__)
@@ -265,7 +266,7 @@ class LgTv:
 
             # Only install on_disconnect after connection seems to work to avoid triggering it while not really connected
             self._on_disconnect = on_disconnect
-        except OSError as e:
+        except (SerialException, OSError) as e:
             raise ConnectionError("Could not connect to LG TV, check the port settings") from e
 
     async def close(self):
@@ -281,7 +282,7 @@ class LgTv:
                 await self._writer.wait_closed()
             except ConnectionError:
                 logger.debug("Connection error while closing", exc_info=True)
-            except OSError:
+            except (SerialException, OSError):
                 logger.debug("Serial exception error while closing", exc_info=True)
 
     async def _do_command(
@@ -349,7 +350,7 @@ class LgTv:
                 logger.warning("Connection error", exc_info=True)
                 await self._close(True)
                 raise e
-            except OSError as e:
+            except (SerialException, OSError) as e:
                 logger.warning("Serial error", exc_info=True)
                 # Why try to close? Can result in more exceptions...
                 # Not sure what happens then

--- a/custom_components/lg_tv_serial/lgtv_api.py
+++ b/custom_components/lg_tv_serial/lgtv_api.py
@@ -7,9 +7,8 @@ from enum import IntEnum, unique
 import logging
 import re
 import sys
-from serial import SerialException  # type: ignore
 
-import serial_asyncio_fast  # type: ignore
+import serialx  # type: ignore
 
 
 logger = logging.getLogger(__name__)
@@ -255,7 +254,7 @@ class LgTv:
         """
         try:
             (self._reader, self._writer) = (
-                await serial_asyncio_fast.open_serial_connection(
+                await serialx.open_serial_connection(
                     url=self._serial_url, baudrate=9600,
                     rtscts=self._rtscts, dsrdtr=self._dsrdtr
                 )
@@ -266,7 +265,7 @@ class LgTv:
 
             # Only install on_disconnect after connection seems to work to avoid triggering it while not really connected
             self._on_disconnect = on_disconnect
-        except SerialException:
+        except (OSError, IOError):
             raise ConnectionError("Could not connect to LG TV, check the port settings")
 
     async def close(self):
@@ -282,7 +281,7 @@ class LgTv:
                 await self._writer.wait_closed()
             except ConnectionError:
                 logger.debug("Connection error while closing", exc_info=True)
-            except SerialException:
+            except (OSError, IOError):
                 logger.debug("Serial exception error while closing", exc_info=True)
 
     async def _do_command(
@@ -350,7 +349,7 @@ class LgTv:
                 logger.warning("Connection error", exc_info=True)
                 await self._close(True)
                 raise e
-            except SerialException as e:
+            except (OSError, IOError) as e:
                 logger.warning("Serial error", exc_info=True)
                 # Why try to close? Can result in more exceptions...
                 # Not sure what happens then

--- a/custom_components/lg_tv_serial/manifest.json
+++ b/custom_components/lg_tv_serial/manifest.json
@@ -5,14 +5,10 @@
     "@mvdwetering"
   ],
   "config_flow": true,
-  "dependencies": [],
   "documentation": "https://github.com/mvdwetering/lg_tv_serial",
-  "homekit": {},
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mvdwetering/lg_tv_serial/issues",
-  "requirements": ["pyserial-asyncio-fast==0.16"],
-  "ssdp": [],
-  "version": "0.0.0",
-  "zeroconf": []
+  "requirements": ["serialx>=1.2.2"],
+  "version": "0.0.0"
 }

--- a/custom_components/lg_tv_serial/translations/en.json
+++ b/custom_components/lg_tv_serial/translations/en.json
@@ -10,7 +10,7 @@
         },
         "step": {
             "user": {
-                "description": "The serial port can be a normal serial port like '/dev/ttyUSB0', but can also be any [URL handler as supported by PySerial]({pyserial_url}).\n\nThis can come in handy when addressing USB adapters by serial with `hwgrep://` or use `rfc2217://hostname_or_ip` to connect through an rfc2217 compatible server for more advanced usecases.",
+                "description": "The serial port can be a normal serial port like '/dev/ttyUSB0', but can also be any [URL handler as supported by serialx]({serialx_url}).\n\nYou can use an [ESPHome serial proxy]({esphome_url}), or use `socket://host:port` / `rfc2217://host:port` to connect to eg. ser2net or generic serial-over-ethernet hardware.",
                 "data": {
                     "serial_url": "Serial port e.g. /dev/ttyUSB0",
                     "set_id": "Set ID",

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
     "name": "LG TV Serial",
     "render_readme": true,
-    "homeassistant": "2025.2.0",
+    "homeassistant": "2026.5.0",
     "zip_release": true,
     "filename": "lg_tv_serial.zip"    
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyserial-asyncio-fast==0.16
+serialx>=1.2.2


### PR DESCRIPTION
Home Assistant is migrating to serialx instead of PySerial and its variants, to better support remote serial ports:
https://www.home-assistant.io/blog/2026/05/06/release-20265/#serial-ports-over-the-network-with-esphome
https://developers.home-assistant.io/blog/2026/04/27/pyserial-to-serialx/

This allows to use ESPHome based serial proxies, in addition to raw TCP and RFC2217 as before.
It also adds a serial port selector to the config flow, with all known local and remote serial ports.

Breaking change: serialx does not (yet) support hwgrep:// urls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved serial port setup with a dedicated selector in the integration UI.

* **Documentation**
  * Updated setup guidance to cover serialx-supported URLs and ESPHome serial proxies, including socket and RFC2217 examples.

* **Chores**
  * Bumped Home Assistant compatibility and updated the integration's serial connectivity dependency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mvdwetering/lg_tv_serial/pull/14)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->